### PR TITLE
修正收音机频率范围

### DIFF
--- a/uvk5_cn.py
+++ b/uvk5_cn.py
@@ -339,7 +339,7 @@ PROG_SIZE = 0x1d00  # size of the memory that we will write
 MEM_BLOCK = 0x80  # largest block of memory that we can reliably write
 
 # fm radio supported frequencies
-FMMIN = 76.0
+FMMIN = 64.0
 FMMAX = 108.0
 
 # bands supported by the UV-K5


### PR DESCRIPTION
MDC 联系人0X1FFF有问题原因依然不明
侧键自定义缺少：M键长按
侧键地址应为0X1FF8~0X1FFC，共5个，顺序为：
 State[0] = gEeprom.KEY_M_LONG_PRESS_ACTION;
 State[1] = gEeprom.KEY_1_SHORT_PRESS_ACTION;
 State[2] = gEeprom.KEY_1_LONG_PRESS_ACTION;
 State[3] = gEeprom.KEY_2_SHORT_PRESS_ACTION;
 State[4] = gEeprom.KEY_2_LONG_PRESS_ACTION;
功能顺序为：
* {关闭, ACTION_OPT_NONE},
* {手电, ACTION_OPT_FLASHLIGHT},
* {切换发射功率, ACTION_OPT_POWER},
* {监听, ACTION_OPT_MONITOR},
* {扫描, ACTION_OPT_SCAN},
* {声控发射,				ACTION_OPT_VOX},
* {FM收音机,		ACTION_OPT_FM},
* {锁定按键, ACTION_OPT_KEYLOCK},
* {切换信道, ACTION_OPT_A_B},
* {切换信道模式, ACTION_OPT_VFO_MR},
* {切换调制模式, ACTION_OPT_SWITCH_DEMODUL},
* {DTMF解码, ACTION_OPT_D_DCD},
* {切换宽窄带, ACTION_OPT_WIDTH},
* {A信道发射, ACTION_OPT_SEND_A},
* {B信道发射, ACTION_OPT_SEND_B},
其中F1、F2短按不具有：
* {A信道发射, ACTION_OPT_SEND_A},
* {B信道发射, ACTION_OPT_SEND_B},

